### PR TITLE
parallelize scan with OpenMP

### DIFF
--- a/cmake/DynamicBuild.cmake
+++ b/cmake/DynamicBuild.cmake
@@ -1,6 +1,7 @@
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -g -O3 -Wall -Wextra -Wpedantic -fno-omit-frame-pointer -fcolor-diagnostics")
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3")
 set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -O3")
+set(CMAKE_BUILD_WITH_INSTALL_RPATH ON)
 
 execute_process(
     COMMAND ${CMAKE_COMMAND} -E copy
@@ -9,8 +10,6 @@ execute_process(
 )
 
 include(cmake/FetchONNX.cmake)
-
-find_package(OpenMP COMPONENTS CXX)
 
 add_executable(deej-ai 
   src/main.cpp
@@ -37,5 +36,4 @@ set_target_properties(deej-ai PROPERTIES
 target_link_libraries(deej-ai PRIVATE
     Eigen3::Eigen
     onnxruntime
-    OpenMP::OpenMP_CXX
 )

--- a/cmake/DynamicBuild.cmake
+++ b/cmake/DynamicBuild.cmake
@@ -10,6 +10,8 @@ execute_process(
 
 include(cmake/FetchONNX.cmake)
 
+find_package(OpenMP COMPONENTS CXX)
+
 add_executable(deej-ai 
   src/main.cpp
   ${DEEJAI_SOURCES}
@@ -35,4 +37,5 @@ set_target_properties(deej-ai PROPERTIES
 target_link_libraries(deej-ai PRIVATE
     Eigen3::Eigen
     onnxruntime
+    OpenMP::OpenMP_CXX
 )

--- a/cmake/StaticBuild.cmake
+++ b/cmake/StaticBuild.cmake
@@ -1,5 +1,6 @@
 set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 
+find_package(OpenMP COMPONENTS CXX)
 
 set(ONNX_STATIC_DIR ${CMAKE_SOURCE_DIR}/onnxruntime-build/onnxruntime)
 add_executable(deej-ai 
@@ -14,6 +15,7 @@ target_include_directories(deej-ai PRIVATE
 
 target_link_libraries(deej-ai PRIVATE
     Eigen3::Eigen
+    OpenMP::OpenMP_CXX
     ${CMAKE_SOURCE_DIR}/onnxruntime-build/output/static_lib/Release/lib/onnxruntime.lib
 )
 

--- a/cmake/StaticBuild.cmake
+++ b/cmake/StaticBuild.cmake
@@ -1,7 +1,5 @@
 set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 
-find_package(OpenMP COMPONENTS CXX)
-
 set(ONNX_STATIC_DIR ${CMAKE_SOURCE_DIR}/onnxruntime-build/onnxruntime)
 add_executable(deej-ai 
     src/main.cpp
@@ -15,7 +13,6 @@ target_include_directories(deej-ai PRIVATE
 
 target_link_libraries(deej-ai PRIVATE
     Eigen3::Eigen
-    OpenMP::OpenMP_CXX
     ${CMAKE_SOURCE_DIR}/onnxruntime-build/output/static_lib/Release/lib/onnxruntime.lib
 )
 

--- a/src/deejai/scanner.cpp
+++ b/src/deejai/scanner.cpp
@@ -6,6 +6,7 @@
 #include <filesystem>
 #include <onnxruntime_cxx_api.h>
 #include <optional>
+#include <queue>
 #include <string>
 #include <unordered_map>
 #include <unsupported/Eigen/CXX11/Tensor>
@@ -149,7 +150,7 @@ double scanner::epsilon() const {
     return m_epsilon_distance;
 }
 
-bool scanner::scan(const std::vector<std::string> &paths) {
+bool scanner::scan(const std::vector<std::string> &paths, int jobs) {
     const std::filesystem::path bundled_dir = std::filesystem::path(m_save_directory) / BUNDLED_VECS_DIRNAME;
     const std::filesystem::path bundled_vecs_path = bundled_dir / BUNDLED_VECS_FILENAME;
 
@@ -172,24 +173,47 @@ bool scanner::scan(const std::vector<std::string> &paths) {
     }
 
     const int total_files = files.size();
-    int current = 0;
-    int files_scanned = 0;
-#pragma omp parallel for schedule(dynamic)
-    for (const auto &file : files) {
-#pragma omp atomic update
-        current++;
-        std::u8string u8 = std::u8string(file.begin(), file.end());
+    std::mutex scan_mutex;
+    std::atomic<int> current{0};
+    auto scan_worker_fun = [&](const std::string &file) {
+        int value = current.fetch_add(1, std::memory_order_relaxed) + 1;
+        std::u8string u8(file.begin(), file.end());
         std::u8string scanned_filename = utils::scanned_filename(u8);
         std::filesystem::path vec_file = std::filesystem::path(m_save_directory) / std::filesystem::path(scanned_filename);
         if (!(std::filesystem::exists(vec_file) && std::filesystem::is_regular_file(vec_file))) {
             scan_file(file);
-            int last_file_scanned; 
-#pragma omp atomic capture
-            { last_file_scanned = files_scanned; files_scanned++; }
-            if (last_file_scanned % 10 == 0) {
-                std::cout << "Scan progress: " << current << " / " << total_files << std::endl;
+            {
+                std::lock_guard<std::mutex> lock(scan_mutex);
+                if (value % 10 == 0) {
+                    std::cout << "Scan progress: " << value << " / " << total_files << std::endl;
+                }
             }
         }
+    };
+
+    size_t max_concurrent = std::thread::hardware_concurrency();
+    if (max_concurrent <= 0) {
+        max_concurrent = 1;
+    }
+
+    if (jobs != -1 && jobs > 0) {
+        max_concurrent = std::min(max_concurrent, static_cast<size_t>(jobs));
+    }
+
+    std::queue<std::thread> threads;
+    for (const auto &file : files) {
+        if (threads.size() >= max_concurrent) {
+            threads.front().join();
+            threads.pop();
+        }
+
+        threads.emplace(scan_worker_fun, file);
+    }
+
+    // Join remaining threads
+    while (!threads.empty()) {
+        threads.front().join();
+        threads.pop();
     }
 
     // load individual file vectors

--- a/src/deejai/scanner.hpp
+++ b/src/deejai/scanner.hpp
@@ -25,7 +25,7 @@ class scanner {
     scanner(scanner &&) = default;
     scanner &operator=(scanner &&) = default;
 
-    bool scan(const std::vector<std::string> &paths);
+    bool scan(const std::vector<std::string> &paths, int jobs = -1);
     std::vector<Ort::Value> predict(const audio_file_tensor &input_tensor);
 
     std::vector<int64_t> input_shape() const;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -98,6 +98,8 @@ int main(int argc, char *argv[]) {
                                     cxxopts::value<int>()->default_value("100"));
         options.add_options("Scan")("e,epsilon", "Epsilon value.",
                                     cxxopts::value<double>()->default_value("0.001"));
+        options.add_options("Scan")("j,jobs", "The maximum number of threads that should be used.",
+                                    cxxopts::value<int>()->default_value("-1"));
         options.add_options("Generate & Reorder")("i,input", "Input song path. This flag can be used multiple times.",
                                                   cxxopts::value<std::string>());
         options.add_options("Generate & Reorder")("o,m3u-out", "The m3u filepath to save the playlist. "
@@ -185,11 +187,12 @@ int main(int argc, char *argv[]) {
             std::string model = result["model"].as<std::string>();
             int batch_size = result["batch-size"].as<int>();
             double epsilon = result["epsilon"].as<double>();
+            int jobs = result["jobs"].as<int>();
 
             deejai::scanner deejai_scanner(model, vec_dir);
             deejai_scanner.set_batch_size(batch_size);
             deejai_scanner.set_epsilon(epsilon);
-            if (deejai_scanner.scan(scan_inputs)) {
+            if (deejai_scanner.scan(scan_inputs, jobs)) {
                 std::cout << "Scan completed successfully." << std::endl;
             }
         }


### PR DESCRIPTION
I appreciate your work both on this and the BetterMix plugin.

This patch parallelizes the scan of the music library.  I have a moderately
large music library and a large but older server, and currently the scan only
uses a single core.  This patch allows me to use more cores on the machine
increasing the throughput of the scan by 24x on my system.

If you are not familiar with OpenMP, it is a widely implemented set of language
extensions for C and C++ that allow easy thread based parallelism.  It is
required dependency of the ONNX runtime the way that you pull it in making a
previously required dependency. The default OpenMP runtime included in GCC
default to using all hardware cores for the scan, if you want to limit the
number of threads you can use the `OMP_NUM_THREADS` environment variable.
